### PR TITLE
Use `navigator.mediaDevices.getUserMedia`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 npm-debug.log
 .travis
+profiles/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: false
 language: node_js
 node_js:
-- 0.10
+- "6"
+- "lts/*"
 
 env:
   matrix:
@@ -18,14 +20,15 @@ matrix:
     - env: BROWSER=chrome  BVER=unstable
     - env: BROWSER=firefox BVER=nightly
 
-before_install:
-  - mkdir -p .travis
-  - curl -s https://codeload.github.com/rtc-io/webrtc-testing-on-travis/tar.gz/master | tar -xz --strip-components=1 --directory .travis
-  - ./.travis/setup.sh
+before_script:
+  - ./node_modules/travis-multirunner/setup.sh
   - export DISPLAY=:99.0
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+  - sh -e /etc/init.d/xvfb start
+
+after_failure:
+  - for file in *.log; do echo $file; echo "======================"; cat $file; done || true
 
 notifications:
   email:
-  - damon.oehlman@nicta.com.au
+  - nathan+rtcio@coviu.com
   irc: irc.freenode.org#rtc.io

--- a/index.js
+++ b/index.js
@@ -36,6 +36,18 @@ module.exports = function(constraints, opts, callback) {
     callback(null, stream);
   }
 
+  function capture() {
+    // Check if we have support for the promises-based `navigator.mediaDevices.getUserMedia` option
+    if (navigator.mediaDevices && typeof navigator.mediaDevices.getUserMedia === 'function') {
+      return navigator.mediaDevices.getUserMedia(constraints).then(handleCapture).catch(callback);
+    }
+    // If we don't, default back to the old detected getUserMedia options
+    if (typeof navigator.getUserMedia != 'function') {
+      return callback(new Error('getUserMedia not supported'));
+    }
+    return navigator.getUserMedia(constraints, handleCapture, callback);
+  }
+
   if (typeof opts == 'function') {
     callback = opts;
     opts = {};
@@ -52,14 +64,9 @@ module.exports = function(constraints, opts, callback) {
       if (typeof navigator.getUserMedia != 'function') {
         return callback(new Error('plugin does not support media capture'));
       }
-
-      navigator.getUserMedia(constraints, handleCapture, callback);
+      capture();
     });
   }
 
-  if (typeof navigator.getUserMedia != 'function') {
-    return callback(new Error('getUserMedia not supported'));
-  }
-
-  navigator.getUserMedia(constraints, handleCapture, callback);
+  capture();
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "rtc-plugin-nicta-ios": "^1.3.4",
     "rtc-plugin-temasys": "^1.1.0",
     "tap-spec": "^4.0.2",
+    "tape": "^3.0.0",
     "travis-multirunner": "^4.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cross browser getUserMedia implementation with support for rtc.io plugins",
   "main": "index.js",
   "scripts": {
-    "test": "testling -x ./.travis/start-$BROWSER.sh",
+    "test": "browserify test/all.js | broth start | tap-spec",
     "gendocs": "gendocs > README.md"
   },
   "stability": "unstable",
@@ -30,10 +30,12 @@
     "rtc-core": "^4.0.0"
   },
   "devDependencies": {
+    "broth": "^2.1.1",
+    "browserify": "^11.0.0",
     "cog": "^1.0.0",
     "rtc-plugin-nicta-ios": "^1.3.4",
     "rtc-plugin-temasys": "^1.1.0",
-    "tape": "^3.0.0",
-    "testling": "^1.7.1"
+    "tap-spec": "^4.0.2",
+    "travis-multirunner": "^4.3.1"
   }
 }

--- a/test/helpers/capture.js
+++ b/test/helpers/capture.js
@@ -3,6 +3,6 @@ var extend = require('cog/extend');
 
 module.exports = function(constraints, opts, callback) {
   return capture(extend({
-    fake: typeof __testlingConsole != 'undefined'
+    fake: true
   }, constraints), opts, callback);
 };


### PR DESCRIPTION
As `navigator.getUserMedia` is now deprecated (and not supported at all on Safari 12), this adds support for using the promises based `navigator.mediaDevices.getUserDevices`.

If will still fallback to using `navigator.getUserMedia` if required.